### PR TITLE
Add state to shipping address

### DIFF
--- a/dropday.php
+++ b/dropday.php
@@ -254,12 +254,21 @@ class Dropday extends Module
             ),
             'products' => array()
         );
+
+        if ($state = State::getNameById($address->id_state)) {
+            $order_data['shipping_address']['state'] = (string) $state;
+        }
+
         if (!Configuration::get('DROPDAY_LIVE_MODE')) {
             $order_data['test'] = true;
         }
         $products = $order->getProducts();
 
         foreach ($products as $product) {
+            
+            $quantity = (int) (isset($product['customizationQuantityTotal']) && $product['customizationQuantityTotal'])
+                ? $product['customizationQuantityTotal']
+                : $product['product_quantity'];
 
             $stockQuantity = false;
             if (Configuration::get('PS_STOCK_MANAGEMENT')) {
@@ -273,9 +282,7 @@ class Dropday extends Module
             }
 
             $cat = new Category((int) $product['id_category_default'], (int) $order->id_lang);
-            $quantity = (int) (isset($product['customizationQuantityTotal']) && $product['customizationQuantityTotal'])
-                ? $product['customizationQuantityTotal']
-                : $product['product_quantity'];
+
             $link_rewrite = $this->getProductLinkRewrite((int) $product['product_id'], (int) $order->id_lang);
 
             $image_url = isset($product['image'])


### PR DESCRIPTION
## How to test

Add an override to test it with the new API. Only the staging website allows `state`.


Place **override/modules/dropday/dropday.php** in your PrestaShop installation:

```
<?php
/**
*   Dropday
*
*   Do not copy, modify or distribute this document in any form.
*
*   @author     Matthijs <matthijs@blauwfruit.nl>
*   @copyright  Copyright (c) 2013-2021 blauwfruit (https://blauwfruit.nl)
*   @license    Proprietary Software
*
*/

if (!defined('_PS_VERSION_')) {
    exit;
}

class DropdayOverride extends Dropday
{
    protected $api_uri = 'https://dropday.blauwfruit.dev/api/v1/';
}
```